### PR TITLE
Allows for optional styling of shutdown entries

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -144,9 +144,9 @@ def _make_grub_cfg_load_our_theme(grub_cfg_content, source_type, resolution_or_n
     epilog_chunks = [
         # Ensure that we always have one or more menu entries
         '',
-        'submenu \'Reboot / Shutdown\' {',
-        '    menuentry Reboot { reboot }',
-        '    menuentry Shutdown { halt }',
+        'submenu \'Reboot / Shutdown\' --class shutdown {',
+        '    menuentry Reboot --class restart { reboot }',
+        '    menuentry Shutdown --class shutdown { halt }',
         '}',
         '',
         'set default=0',  # i.e. move cursor to first entry


### PR DESCRIPTION
if icons for shutdown and restart are defined, they will show up. Otherwise this will revert to existing behavior (of not showing anything)