### PR TITLE
Handle troublesome existing lines "set gfxmode=auto" in grub config (fixes #64)

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -170,6 +170,16 @@ def _make_grub_cfg_load_our_theme(grub_cfg_content, source_type, resolution_or_n
                               grub_cfg_content,
                               flags=re.MULTILINE)
 
+    if resolution_or_none is not None:
+        # Get rid of potential overwrites to variable "gfxmode",
+        # in particular case "set gfxmode=auto".
+        grub_cfg_content = re.sub('^([ \\t]*set gfxmode=)(.+)',
+                                  ('\\g<1>%dx%d'
+                                   '  # replaced by grub2-theme-preview, was \\2')
+                                  % resolution_or_none,
+                                  grub_cfg_content,
+                                  flags=re.MULTILINE)
+
     return '\n'.join(prolog_chunks) + grub_cfg_content + '\n'.join(epilog_chunks)
 
 


### PR DESCRIPTION
To try out locally, e.g.:

```console
# cd "$(mktemp -d)"
# git clone --branch issue-64-improve-support-for-custom-resolution --depth 1 https://github.com/hartwork/grub2-theme-preview
# cd grub2-theme-preview/
# python3 -m venv venv/
# source venv/bin/activate
# pip install -e .
# grub2-theme-preview ...............
```

CC @Lowrida