### PR TITLE
Add Void Linux support and change the way UEFI image is loaded in qemu.

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -381,6 +381,7 @@ def _grub2_ovmf_tuple():
             '/usr/share/edk2-ovmf/x64/OVMF_CODE.fd',  # Arch Linux and its derivatives
             '/usr/share/OVMF/OVMF_CODE.fd',  # Debian and its derivatives
             '/usr/share/edk2/ovmf/OVMF_CODE.fd',  # Fedora (and its derivatives?)
+            '/usr/share/qemu/edk2-x86_64-code.fd',  # Void Linux
         ]
 
     for candidate in candidates:

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -525,8 +525,7 @@ def _inner_main(options):
                     run_command.append('-full-screen')
                 if is_efi_host:
                     run_command += [
-                        '-bios',
-                        omvf_image_path,
+                        '-drive', f'if=pflash,format=raw,readonly,file={omvf_image_path}'
                     ]
 
                 print('INFO: Please give GRUB a moment to show up in QEMU...')


### PR DESCRIPTION
* Added candidate `/usr/share/qemu/edk2-x86_64-code.fd` as a search path for OVMF image.
* Changed `-bios` with `-drive`, with the old -bios option, it was `qemu: could not load PC BIOS '/usr/share/qemu/edk2-x86_64-code.fd'`.

I believe I found this format of specifying uefi image from [this article](https://krinkinmu.github.io/2020/10/11/efi-getting-started.html), in the "Testing" part.

---

Example:

![23-05-09-22h29m22s](https://github.com/hartwork/grub2-theme-preview/assets/26714676/a0dfddb2-0290-4d1f-835f-f33f4bda78fb)

