### PR TITLE
Add OVMF_CODE_4M.fd to list of candidates

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -379,7 +379,8 @@ def _grub2_ovmf_tuple():
         candidates = [
             '/usr/share/edk2-ovmf/OVMF_CODE.fd',  # Gentoo and its derivatives
             '/usr/share/edk2-ovmf/x64/OVMF_CODE.fd',  # Arch Linux and its derivatives
-            '/usr/share/OVMF/OVMF_CODE.fd',  # Debian and its derivatives
+            '/usr/share/OVMF/OVMF_CODE.fd',  # Older Debian and its derivatives
+            '/usr/share/OVMF/OVMF_CODE_4M.fd',  # Debian and its derivatives
             '/usr/share/edk2/ovmf/OVMF_CODE.fd',  # Fedora (and its derivatives?)
             '/usr/share/qemu/edk2-x86_64-code.fd',  # Void Linux
         ]


### PR DESCRIPTION
On my Debian Unstable system, I don't have `/usr/share/OVMF/OVMF_CODE.fd`, I have `/usr/share/OVMF/OVMF_CODE_4M.fd` instead, add it to the candidate list.

Admittedly this is PR untested, but it's trivial and adding a symlink between the 2 fixed it locally to test there weren't any other issues