### PR TITLE
Stop using deprecated short-form of boolean option 'readonly' with QEMU

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -546,7 +546,7 @@ def _inner_main(options):
                     run_command.append('-full-screen')
                 if is_efi_host:
                     run_command += [
-                        '-drive', f'if=pflash,format=raw,readonly,file={omvf_image_path}'
+                        '-drive', f'if=pflash,format=raw,readonly=on,file={omvf_image_path}'
                     ]
 
                 print('INFO: Please give GRUB a moment to show up in QEMU...')


### PR DESCRIPTION
Symptom was:
```
qemu-system-x86_64: -drive if=pflash,format=raw,readonly,file=/usr/share/edk2-ovmf/OVMF_CODE.fd:
  warning: short-form boolean option 'readonly' deprecated
Please use readonly=on instead
```