### PR TITLE
Feature: Add option to save relevant grub debug

### DIFF
--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -157,17 +157,14 @@ def _make_grub_cfg_load_our_theme(
         "insmod jpeg",
     ]
 
-    terminal_input_line = "terminal_input console serial"
     terminal_output_line = "terminal_output gfxterm"
     if save_grub_debug:
-        terminal_output_line += " serial console"
+        terminal_output_line += " serial"
 
     if resolution_or_none is not None:
         # We need to be the first call to 'terminal_output gfxterm'
         # if we want to have a say with resolution
         prolog_chunks.append("set gfxmode=%dx%d" % resolution_or_none)
-        if save_grub_debug:
-            prolog_chunks.append(terminal_input_line)
         prolog_chunks.append(terminal_output_line)
 
     prolog_chunks.append("")  # blank line
@@ -188,8 +185,6 @@ def _make_grub_cfg_load_our_theme(
     if resolution_or_none is None:
         # If we haven't ensured GFX mode earlier, do it now
         # so it's done at least once
-        if save_grub_debug:
-            epilog_chunks.append(terminal_input_line)
         epilog_chunks.append(terminal_output_line)
 
     if source_type == _SourceType.DIRECTORY:

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -134,7 +134,8 @@ def _make_grub_cfg_load_our_theme(
 ):
     prolog_chunks = []
     if save_grub_debug:
-        # With --grub-debug-file: GRUB emits debug on COM1; QEMU -serial file:PATH stores it on the host.
+        # When --grub-debug-file is set: GRUB uses COM1 for debug.
+        # QEMU -serial file records that stream to the given path.
         prolog_chunks.append(f"set debug={_GRUB_DEBUG_SPEC}")
         prolog_chunks.append("serial --unit=0")
 

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -687,13 +687,14 @@ def _inner_main(options):
 
                 qemu_exit_code = _run(run_command, options.verbose)
 
-                if qemu_exit_code not in (0, _KILL_BY_SIGNAL + signal.SIGINT):
-                    raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
                 if vm_serial_capture_path is not None:
                     print(
                         f"INFO: Wrote the virtual machine's serial log "
                         f'(with the GRUB debug output) to file "{vm_serial_capture_path}".'
                     )
+
+                if qemu_exit_code not in (0, _KILL_BY_SIGNAL + signal.SIGINT):
+                    raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
             finally:
                 with contextlib.suppress(OSError):
                     os.remove(abs_tmp_img_file)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -130,10 +130,10 @@ def _make_grub_cfg_load_our_theme(
     resolution_or_none,
     font_files_to_load,
     timeout_seconds,
-    save_grub_debug,
+    serial_grub_debug,
 ):
     prolog_chunks = []
-    if save_grub_debug:
+    if serial_grub_debug:
         # When --grub-debug-file is set: GRUB uses COM1 for debug.
         # QEMU -serial file records that stream to the given path.
         prolog_chunks.append(f"set debug={_GRUB_DEBUG_SPEC}")
@@ -156,7 +156,7 @@ def _make_grub_cfg_load_our_theme(
     ]
 
     terminal_output_line = "terminal_output gfxterm"
-    if save_grub_debug:
+    if serial_grub_debug:
         terminal_output_line += " serial"
 
     if resolution_or_none is not None:
@@ -208,7 +208,7 @@ def _make_final_grub_cfg_content(
     resolution_or_none,
     font_files_to_load,
     timeout_seconds,
-    save_grub_debug,
+    serial_grub_debug,
 ):
     if source_grub_cfg is not None:
         files_to_try_to_read = [source_grub_cfg]
@@ -252,7 +252,7 @@ def _make_final_grub_cfg_content(
         resolution_or_none,
         font_files_to_load,
         timeout_seconds,
-        save_grub_debug,
+        serial_grub_debug,
     )
 
 
@@ -555,6 +555,7 @@ def _inner_main(options):
         font_files_to_load = list(iterate_pf2_files_relative(normalized_source))
 
     vm_serial_capture_path = options.grub_debug_file
+    serial_grub_debug = vm_serial_capture_path is not None
 
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(
@@ -563,7 +564,7 @@ def _inner_main(options):
         options.resolution,
         font_files_to_load,
         options.timeout_seconds,
-        vm_serial_capture_path is not None,
+        serial_grub_debug,
     )
     if options.debug:
         _dump_grub_cfg_content(grub_cfg_content, target=sys.stderr)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -551,7 +551,6 @@ def _inner_main(options):
     else:
         guest_serial_capture_path = None
 
-
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(
         source_type,
@@ -673,8 +672,12 @@ def _inner_main(options):
                     except OSError as e:
                         raise OSError(
                             errno.EIO,
-                            f"cannot create or truncate grub serial capture '{guest_serial_capture_path}': {e}",
+                            (
+                                "cannot create or truncate grub serial capture "
+                                f"'{guest_serial_capture_path}': {e}"
+                            ),
                         )
+
                     run_command.extend(["-serial", f"file:{guest_serial_capture_path}"])
                 if is_efi_host:
                     run_command += [

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -24,7 +24,6 @@ _PATH_IMAGE_ONLY_TGA = "themes/DEMO.tga"
 _PATH_IMAGE_ONLY_JPEG = "themes/DEMO.jpeg"
 _PATH_FULL_THEME = "themes/DEMO"
 _GRUB_DEBUG_SPEC = "all,-efidisk,-lexer,-scripting,-verify"
-_GRUB_DEBUG_FILE = "grub-debug.txt"
 
 _KILL_BY_SIGNAL = 128
 
@@ -137,7 +136,7 @@ def _make_grub_cfg_load_our_theme(
     if save_grub_debug:
         prolog_chunks.append("set debug=%s" % _GRUB_DEBUG_SPEC)
         prolog_chunks.append(
-            # COM1: QEMU attaches -serial file:... for --save-grub-debug captures
+            # COM1: QEMU attaches -serial file:... when --grub-debug-file PATH is given
             "serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1",
         )
 
@@ -416,17 +415,21 @@ def parse_command_line(argv):
         " shows up a GRUB shell, successfully.",
     )
     debugging.add_argument(
-        "--save-grub-debug",
-        dest="save_grub_debug",
-        default=False,
-        action="store_true",
+        "--grub-debug-file",
+        dest="grub_debug_file",
+        default=None,
+        metavar="PATH",
         help=(
-            f"QEMU `-serial file` writes guest COM1 to {_GRUB_DEBUG_FILE} (cwd, truncated each "
-            f"run); grub.cfg gains set debug={_GRUB_DEBUG_SPEC} and terminals that mirror to serial."
+            "QEMU `-serial file:PATH` writes guest COM1 to PATH "
+            "(file is truncated each run); generated grub.cfg adds "
+            f"set debug={_GRUB_DEBUG_SPEC} plus serial/mirroring directives."
         ),
     )
 
     options = parser.parse_args(argv[1:])
+
+    if options.grub_debug_file is not None:
+        options.grub_debug_file = os.path.abspath(options.grub_debug_file)
 
     if options.qemu is None:
         import platform
@@ -540,10 +543,7 @@ def _inner_main(options):
     else:
         font_files_to_load = list(iterate_pf2_files_relative(normalized_source))
 
-    if options.save_grub_debug:
-        guest_serial_capture_path = os.path.abspath(os.path.join(os.getcwd(), _GRUB_DEBUG_FILE))
-    else:
-        guest_serial_capture_path = None
+    guest_serial_capture_path = options.grub_debug_file
 
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(
@@ -552,7 +552,7 @@ def _inner_main(options):
         options.resolution,
         font_files_to_load,
         options.timeout_seconds,
-        options.save_grub_debug,
+        guest_serial_capture_path is not None,
     )
     if options.debug:
         _dump_grub_cfg_content(grub_cfg_content, target=sys.stderr)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -134,11 +134,9 @@ def _make_grub_cfg_load_our_theme(
 ):
     prolog_chunks = []
     if save_grub_debug:
-        prolog_chunks.append("set debug=%s" % _GRUB_DEBUG_SPEC)
-        prolog_chunks.append(
-            # COM1: QEMU attaches -serial file:... when --grub-debug-file PATH is given
-            "serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1",
-        )
+        # GRUB-side debug log mirrored to a file.
+        prolog_chunks.append(f"set debug={_GRUB_DEBUG_SPEC}")
+        prolog_chunks.append("serial")
 
     # NOTE: The last font loaded becomes the default/fallback font
     #       So if we load fonts first, the remaining default font

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -23,6 +23,8 @@ _PATH_IMAGE_ONLY_PNG = "themes/DEMO.png"
 _PATH_IMAGE_ONLY_TGA = "themes/DEMO.tga"
 _PATH_IMAGE_ONLY_JPEG = "themes/DEMO.jpeg"
 _PATH_FULL_THEME = "themes/DEMO"
+_GRUB_DEBUG_SPEC = "all,-scripting,-lexer,-efidisk,-verify"
+_GRUB_DEBUG_FILE = "grub-debug.txt"
 
 _KILL_BY_SIGNAL = 128
 
@@ -112,14 +114,25 @@ def _generate_dummy_menu_entries():
 
 
 def _make_grub_cfg_load_our_theme(
-    grub_cfg_content, source_type, resolution_or_none, font_files_to_load, timeout_seconds
+    grub_cfg_content,
+    source_type,
+    resolution_or_none,
+    font_files_to_load,
+    timeout_seconds,
+    save_grub_debug=False,
 ):
     # NOTE: The last font loaded becomes the default/fallback font
     #       So if we load fonts first, the remaining default font
     #       will remain unchanged and the theme will display unchanged.
-    prolog_chunks = [
-        "loadfont $prefix/fonts/unicode.pf2",
-    ]
+    prolog_chunks = []
+    if save_grub_debug:
+        prolog_chunks.append("set debug=%s" % _GRUB_DEBUG_SPEC)
+        prolog_chunks.append(
+            # COM1: QEMU attaches -serial file:... for --save-grub-debug captures
+            "serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1",
+        )
+
+    prolog_chunks.append("loadfont $prefix/fonts/unicode.pf2")
 
     for relative_path in font_files_to_load:
         prolog_chunks.append(f"loadfont $prefix/{_PATH_FULL_THEME}/{relative_path}")
@@ -132,11 +145,18 @@ def _make_grub_cfg_load_our_theme(
         "insmod jpeg",
     ]
 
+    term_out_terminal = (
+        "terminal_output gfxterm serial console"
+        if save_grub_debug else "terminal_output gfxterm"
+    )
+
     if resolution_or_none is not None:
         # We need to be the first call to 'terminal_output gfxterm'
         # if we want to have a say with resolution
         prolog_chunks.append("set gfxmode=%dx%d" % resolution_or_none)
-        prolog_chunks.append("terminal_output gfxterm")
+        if save_grub_debug:
+            prolog_chunks.append("terminal_input console serial")
+        prolog_chunks.append(term_out_terminal)
 
     prolog_chunks.append("")  # blank line
     prolog_chunks.append("")  # trailing new line
@@ -156,7 +176,9 @@ def _make_grub_cfg_load_our_theme(
     if resolution_or_none is None:
         # If we haven't ensured GFX mode earlier, do it now
         # so it's done at least once
-        epilog_chunks.append("terminal_output gfxterm")
+        if save_grub_debug:
+            epilog_chunks.append("terminal_input console serial")
+        epilog_chunks.append(term_out_terminal)
 
     if source_type == _SourceType.DIRECTORY:
         epilog_chunks.append("set theme=$prefix/%s/theme.txt" % _PATH_FULL_THEME)
@@ -176,7 +198,12 @@ def _make_grub_cfg_load_our_theme(
 
 
 def _make_final_grub_cfg_content(
-    source_type, source_grub_cfg, resolution_or_none, font_files_to_load, timeout_seconds
+    source_type,
+    source_grub_cfg,
+    resolution_or_none,
+    font_files_to_load,
+    timeout_seconds,
+    save_grub_debug=False,
 ):
     if source_grub_cfg is not None:
         files_to_try_to_read = [source_grub_cfg]
@@ -215,7 +242,12 @@ def _make_final_grub_cfg_content(
         content = _generate_dummy_menu_entries()
 
     return _make_grub_cfg_load_our_theme(
-        content, source_type, resolution_or_none, font_files_to_load, timeout_seconds
+        content,
+        source_type,
+        resolution_or_none,
+        font_files_to_load,
+        timeout_seconds,
+        save_grub_debug,
     )
 
 
@@ -376,6 +408,17 @@ def parse_command_line(argv):
         "useful for checking if a plain GRUB rescue image"
         " shows up a GRUB shell, successfully.",
     )
+    debugging.add_argument(
+        "--save-grub-debug",
+        dest="save_grub_debug",
+        default=False,
+        action="store_true",
+        help=(
+            "QEMU `-serial file` writes guest COM1 to %s (cwd, truncated each "
+            "run); grub.cfg gains set debug=%s and terminals that mirror to serial."
+            % (_GRUB_DEBUG_FILE, _GRUB_DEBUG_SPEC)
+        ),
+    )
 
     options = parser.parse_args(argv[1:])
 
@@ -491,6 +534,11 @@ def _inner_main(options):
     else:
         font_files_to_load = list(iterate_pf2_files_relative(normalized_source))
 
+    guest_serial_capture_path = (
+        os.path.abspath(os.path.join(os.getcwd(), _GRUB_DEBUG_FILE))
+        if options.save_grub_debug else None
+    )
+
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(
         source_type,
@@ -498,6 +546,7 @@ def _inner_main(options):
         options.resolution,
         font_files_to_load,
         options.timeout_seconds,
+        options.save_grub_debug,
     )
     if options.debug:
         _dump_grub_cfg_content(grub_cfg_content, target=sys.stderr)
@@ -604,6 +653,16 @@ def _inner_main(options):
                     run_command += ["-vga", options.qemu_vga]
                 if options.qemu_full_screen:
                     run_command.append("-full-screen")
+                if guest_serial_capture_path is not None:
+                    try:
+                        with open(guest_serial_capture_path, "wb"):
+                            pass
+                    except OSError as e:
+                        raise OSError(
+                            errno.EIO,
+                            f"cannot create or truncate grub serial capture '{guest_serial_capture_path}': {e}",
+                        )
+                    run_command.extend(["-serial", f"file:{guest_serial_capture_path}"])
                 if is_efi_host:
                     run_command += [
                         "-drive",
@@ -616,6 +675,11 @@ def _inner_main(options):
 
                 if qemu_exit_code not in (0, _KILL_BY_SIGNAL + signal.SIGINT):
                     raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
+                if guest_serial_capture_path is not None:
+                    print(
+                        'INFO: Wrote guest serial / GRUB trace to "%s".'
+                        % guest_serial_capture_path
+                    )
             finally:
                 with contextlib.suppress(OSError):
                     os.remove(abs_tmp_img_file)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -215,7 +215,7 @@ def _make_final_grub_cfg_content(
     resolution_or_none,
     font_files_to_load,
     timeout_seconds,
-    save_grub_debug=False,
+    save_grub_debug,
 ):
     if source_grub_cfg is not None:
         files_to_try_to_read = [source_grub_cfg]

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -130,7 +130,7 @@ def _make_grub_cfg_load_our_theme(
     resolution_or_none,
     font_files_to_load,
     timeout_seconds,
-    save_grub_debug=False,
+    save_grub_debug,
 ):
     prolog_chunks = []
     if save_grub_debug:

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -103,11 +103,23 @@ def _generate_dummy_menu_entries():
             reboot
         }
 
+        menuentry 'FreeBSD' --class freebsd --class bsd --class os {
+            reboot
+        }
+
         menuentry 'Gentoo' --class gentoo --class gnu-linux --class linux --class gnu --class os {
             reboot
         }
 
         menuentry "Memtest86+" --class memtest {
+            reboot
+        }
+
+        menuentry "Windows" --class windows --class os {
+            reboot
+        }
+
+        menuentry "macOS" --class macos --class darwin --class os {
             reboot
         }
     """)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -420,7 +420,7 @@ def parse_command_line(argv):
         default=None,
         metavar="PATH",
         help=(
-            "QEMU `-serial file:PATH` writes guest COM1 to PATH "
+            "QEMU `-serial file:PATH` writes the virtual machine's COM1 to PATH "
             "(file is truncated each run); generated grub.cfg adds "
             f"set debug={_GRUB_DEBUG_SPEC} plus serial/mirroring directives."
         ),
@@ -557,7 +557,7 @@ def _inner_main(options):
     else:
         font_files_to_load = list(iterate_pf2_files_relative(normalized_source))
 
-    guest_serial_capture_path = options.grub_debug_file
+    vm_serial_capture_path = options.grub_debug_file
 
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(
@@ -566,7 +566,7 @@ def _inner_main(options):
         options.resolution,
         font_files_to_load,
         options.timeout_seconds,
-        guest_serial_capture_path is not None,
+        vm_serial_capture_path is not None,
     )
     if options.debug:
         _dump_grub_cfg_content(grub_cfg_content, target=sys.stderr)
@@ -674,10 +674,10 @@ def _inner_main(options):
                 if options.qemu_full_screen:
                     run_command.append("-full-screen")
 
-                if guest_serial_capture_path is not None:
+                if vm_serial_capture_path is not None:
                     # Truncate any previous output so each run writes a fresh log
-                    truncate_grub_debug_file(guest_serial_capture_path)
-                    run_command.extend(["-serial", f"file:{guest_serial_capture_path}"])
+                    truncate_grub_debug_file(vm_serial_capture_path)
+                    run_command.extend(["-serial", f"file:{vm_serial_capture_path}"])
 
                 if is_efi_host:
                     run_command += [
@@ -691,9 +691,9 @@ def _inner_main(options):
 
                 if qemu_exit_code not in (0, _KILL_BY_SIGNAL + signal.SIGINT):
                     raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
-                if guest_serial_capture_path is not None:
+                if vm_serial_capture_path is not None:
                     print(
-                        f'INFO: Wrote the virtual machine\'s serial log (with the GRUB debug output) to file "{guest_serial_capture_path}".'
+                        f'INFO: Wrote the virtual machine\'s serial log (with the GRUB debug output) to file "{vm_serial_capture_path}".'
                     )
             finally:
                 with contextlib.suppress(OSError):

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -672,7 +672,7 @@ def _inner_main(options):
                 if options.qemu_full_screen:
                     run_command.append("-full-screen")
 
-                if vm_serial_capture_path is not None:
+                if serial_grub_debug:
                     # Truncate any previous output so each run writes a fresh log
                     truncate_grub_debug_file(vm_serial_capture_path)
                     run_command.extend(["-serial", f"file:{vm_serial_capture_path}"])
@@ -687,7 +687,7 @@ def _inner_main(options):
 
                 qemu_exit_code = _run(run_command, options.verbose)
 
-                if vm_serial_capture_path is not None:
+                if serial_grub_debug:
                     print(
                         f"INFO: Wrote the virtual machine's serial log "
                         f'(with the GRUB debug output) to file "{vm_serial_capture_path}".'

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -134,10 +134,10 @@ def _make_grub_cfg_load_our_theme(
 ):
     prolog_chunks = []
     if serial_grub_debug:
-        # When --grub-debug-file is set: GRUB uses COM1 for debug.
-        # QEMU -serial file records that stream to the given path.
+        # Adding debug to GRUB's config emits it on serial and QEMU -serial file records COM1.
+        # See https://www.gnu.org/software/grub/manual/grub/html_node/serial.html
         prolog_chunks.append(f"set debug={_GRUB_DEBUG_SPEC}")
-        prolog_chunks.append("serial --unit=0")
+        prolog_chunks.append("serial")
 
     # NOTE: The last font loaded becomes the default/fallback font
     #       So if we load fonts first, the remaining default font

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -134,9 +134,9 @@ def _make_grub_cfg_load_our_theme(
 ):
     prolog_chunks = []
     if save_grub_debug:
-        # GRUB-side debug log mirrored to a file.
+        # With --grub-debug-file: GRUB emits debug on COM1; QEMU -serial file:PATH stores it on the host.
         prolog_chunks.append(f"set debug={_GRUB_DEBUG_SPEC}")
-        prolog_chunks.append("serial")
+        prolog_chunks.append("serial --unit=0")
 
     # NOTE: The last font loaded becomes the default/fallback font
     #       So if we load fonts first, the remaining default font

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -133,9 +133,6 @@ def _make_grub_cfg_load_our_theme(
     timeout_seconds,
     save_grub_debug=False,
 ):
-    # NOTE: The last font loaded becomes the default/fallback font
-    #       So if we load fonts first, the remaining default font
-    #       will remain unchanged and the theme will display unchanged.
     prolog_chunks = []
     if save_grub_debug:
         prolog_chunks.append("set debug=%s" % _GRUB_DEBUG_SPEC)
@@ -144,6 +141,9 @@ def _make_grub_cfg_load_our_theme(
             "serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1",
         )
 
+    # NOTE: The last font loaded becomes the default/fallback font
+    #       So if we load fonts first, the remaining default font
+    #       will remain unchanged and the theme will display unchanged.
     prolog_chunks.append("loadfont $prefix/fonts/unicode.pf2")
 
     for relative_path in font_files_to_load:

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -23,7 +23,7 @@ _PATH_IMAGE_ONLY_PNG = "themes/DEMO.png"
 _PATH_IMAGE_ONLY_TGA = "themes/DEMO.tga"
 _PATH_IMAGE_ONLY_JPEG = "themes/DEMO.jpeg"
 _PATH_FULL_THEME = "themes/DEMO"
-_GRUB_DEBUG_SPEC = "all,-scripting,-lexer,-efidisk,-verify"
+_GRUB_DEBUG_SPEC = "all,-efidisk,-lexer,-scripting,-verify"
 _GRUB_DEBUG_FILE = "grub-debug.txt"
 
 _KILL_BY_SIGNAL = 128

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -416,7 +416,6 @@ def parse_command_line(argv):
     debugging.add_argument(
         "--grub-debug-file",
         dest="grub_debug_file",
-        default=None,
         metavar="PATH",
         help=(
             "QEMU `-serial file:PATH` writes the virtual machine's COM1 to PATH "

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -693,7 +693,7 @@ def _inner_main(options):
                     raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
                 if guest_serial_capture_path is not None:
                     print(
-                        'INFO: Wrote guest serial / GRUB trace to "%s".'
+                        'INFO: Wrote the virtual machine's serial log (with the GRUB debug output) to file "%s".'
                         % guest_serial_capture_path
                     )
             finally:

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -111,15 +111,15 @@ def _generate_dummy_menu_entries():
             reboot
         }
 
-        menuentry "Memtest86+" --class memtest {
+        menuentry 'macOS' --class macos --class darwin --class os {
             reboot
         }
 
-        menuentry "Windows" --class windows --class os {
+        menuentry 'Memtest86+' --class memtest {
             reboot
         }
 
-        menuentry "macOS" --class macos --class darwin --class os {
+        menuentry 'Windows' --class windows --class os {
             reboot
         }
     """)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -673,7 +673,7 @@ def _inner_main(options):
                         raise OSError(
                             errno.EIO,
                             (
-                                "cannot create or truncate grub serial capture "
+                                "Cannot create or truncate grub serial capture "
                                 f"'{guest_serial_capture_path}': {e}"
                             ),
                         )

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -671,7 +671,7 @@ def _inner_main(options):
                             pass
                     except OSError as e:
                         raise OSError(
-                            errno.EIO,
+                            e.errno,
                             (
                                 "Cannot create or truncate grub serial capture "
                                 f"'{guest_serial_capture_path}': {e}"

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -157,18 +157,18 @@ def _make_grub_cfg_load_our_theme(
         "insmod jpeg",
     ]
 
+    terminal_input_line = "terminal_input console serial"
+    terminal_output_line = "terminal_output gfxterm"
     if save_grub_debug:
-        term_out_terminal = "terminal_output gfxterm serial console"
-    else:
-        term_out_terminal = "terminal_output gfxterm"
+        terminal_output_line += " serial console"
 
     if resolution_or_none is not None:
         # We need to be the first call to 'terminal_output gfxterm'
         # if we want to have a say with resolution
         prolog_chunks.append("set gfxmode=%dx%d" % resolution_or_none)
         if save_grub_debug:
-            prolog_chunks.append("terminal_input console serial")
-        prolog_chunks.append(term_out_terminal)
+            prolog_chunks.append(terminal_input_line)
+        prolog_chunks.append(terminal_output_line)
 
     prolog_chunks.append("")  # blank line
     prolog_chunks.append("")  # trailing new line
@@ -189,8 +189,8 @@ def _make_grub_cfg_load_our_theme(
         # If we haven't ensured GFX mode earlier, do it now
         # so it's done at least once
         if save_grub_debug:
-            epilog_chunks.append("terminal_input console serial")
-        epilog_chunks.append(term_out_terminal)
+            epilog_chunks.append(terminal_input_line)
+        epilog_chunks.append(terminal_output_line)
 
     if source_type == _SourceType.DIRECTORY:
         epilog_chunks.append("set theme=$prefix/%s/theme.txt" % _PATH_FULL_THEME)

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -157,10 +157,10 @@ def _make_grub_cfg_load_our_theme(
         "insmod jpeg",
     ]
 
-    term_out_terminal = (
-        "terminal_output gfxterm serial console"
-        if save_grub_debug else "terminal_output gfxterm"
-    )
+    if save_grub_debug:
+        term_out_terminal = "terminal_output gfxterm serial console"
+    else:
+        term_out_terminal = "terminal_output gfxterm"
 
     if resolution_or_none is not None:
         # We need to be the first call to 'terminal_output gfxterm'
@@ -546,10 +546,11 @@ def _inner_main(options):
     else:
         font_files_to_load = list(iterate_pf2_files_relative(normalized_source))
 
-    guest_serial_capture_path = (
-        os.path.abspath(os.path.join(os.getcwd(), _GRUB_DEBUG_FILE))
-        if options.save_grub_debug else None
-    )
+    if options.save_grub_debug:
+        guest_serial_capture_path = os.path.abspath(os.path.join(os.getcwd(), _GRUB_DEBUG_FILE))
+    else:
+        guest_serial_capture_path = None
+
 
     abs_grub_cfg_or_none = options.grub_cfg and os.path.abspath(options.grub_cfg)
     grub_cfg_content = _make_final_grub_cfg_content(

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -420,7 +420,8 @@ def parse_command_line(argv):
         help=(
             "QEMU `-serial file:PATH` writes the virtual machine's COM1 to PATH "
             "(file is truncated each run); generated grub.cfg adds "
-            f"set debug={_GRUB_DEBUG_SPEC} plus serial/mirroring directives."
+            f"set debug={_GRUB_DEBUG_SPEC} plus serial/mirroring directives. "
+            "Breaks normal preview operation, only use for debugging GRUB itself."
         ),
     )
 

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -521,6 +521,20 @@ def _require_recursive_read_access_at(abs_path):
                 raise OSError(errno.EACCES, "Permission denied: '%s'" % abs_path)
 
 
+def truncate_grub_debug_file(abs_path):
+    try:
+        with open(abs_path, "wb"):
+            pass
+    except OSError as e:
+        raise OSError(
+            e.errno,
+            (
+                "Cannot create or truncate grub serial capture "
+                f"'{abs_path}': {e}"
+            ),
+        )
+
+
 def _inner_main(options):
     for command, package in (
         (options.grub2_mkrescue, "Grub 2.x"),
@@ -659,20 +673,12 @@ def _inner_main(options):
                     run_command += ["-vga", options.qemu_vga]
                 if options.qemu_full_screen:
                     run_command.append("-full-screen")
-                if guest_serial_capture_path is not None:
-                    try:
-                        with open(guest_serial_capture_path, "wb"):
-                            pass
-                    except OSError as e:
-                        raise OSError(
-                            e.errno,
-                            (
-                                "Cannot create or truncate grub serial capture "
-                                f"'{guest_serial_capture_path}': {e}"
-                            ),
-                        )
 
+                if guest_serial_capture_path is not None:
+                    # Truncate any previous output so each run writes a fresh log
+                    truncate_grub_debug_file(guest_serial_capture_path)
                     run_command.extend(["-serial", f"file:{guest_serial_capture_path}"])
+
                 if is_efi_host:
                     run_command += [
                         "-drive",

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -415,7 +415,6 @@ def parse_command_line(argv):
     )
     debugging.add_argument(
         "--grub-debug-file",
-        dest="grub_debug_file",
         metavar="PATH",
         help=(
             "QEMU `-serial file:PATH` writes the virtual machine's COM1 to PATH "

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -527,10 +527,7 @@ def truncate_grub_debug_file(abs_path):
     except OSError as e:
         raise OSError(
             e.errno,
-            (
-                "Cannot create or truncate grub serial capture "
-                f"'{abs_path}': {e}"
-            ),
+            (f"Cannot create or truncate grub serial capture '{abs_path}': {e}"),
         )
 
 
@@ -692,7 +689,8 @@ def _inner_main(options):
                     raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
                 if vm_serial_capture_path is not None:
                     print(
-                        f'INFO: Wrote the virtual machine\'s serial log (with the GRUB debug output) to file "{vm_serial_capture_path}".'
+                        f"INFO: Wrote the virtual machine's serial log "
+                        f'(with the GRUB debug output) to file "{vm_serial_capture_path}".'
                     )
             finally:
                 with contextlib.suppress(OSError):

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -421,9 +421,8 @@ def parse_command_line(argv):
         default=False,
         action="store_true",
         help=(
-            "QEMU `-serial file` writes guest COM1 to %s (cwd, truncated each "
-            "run); grub.cfg gains set debug=%s and terminals that mirror to serial."
-            % (_GRUB_DEBUG_FILE, _GRUB_DEBUG_SPEC)
+            f"QEMU `-serial file` writes guest COM1 to {_GRUB_DEBUG_FILE} (cwd, truncated each "
+            f"run); grub.cfg gains set debug={_GRUB_DEBUG_SPEC} and terminals that mirror to serial."
         ),
     )
 
@@ -688,8 +687,7 @@ def _inner_main(options):
                     raise RuntimeError(f"QEMU exited with code {qemu_exit_code}.")
                 if guest_serial_capture_path is not None:
                     print(
-                        'INFO: Wrote the virtual machine's serial log (with the GRUB debug output) to file "%s".'
-                        % guest_serial_capture_path
+                        f'INFO: Wrote the virtual machine\'s serial log (with the GRUB debug output) to file "{guest_serial_capture_path}".'
                     )
             finally:
                 with contextlib.suppress(OSError):

--- a/grub2_theme_preview/__main__.py
+++ b/grub2_theme_preview/__main__.py
@@ -528,7 +528,7 @@ def truncate_grub_debug_file(abs_path):
     except OSError as e:
         raise OSError(
             e.errno,
-            (f"Cannot create or truncate grub serial capture '{abs_path}': {e}"),
+            f"Cannot create or truncate grub serial capture '{abs_path}': {e}",
         )
 
 

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -186,8 +186,11 @@ class CliTest(unittest.TestCase):
             ):
                 main(argv)
             dump = stderr.getvalue()
-            self.assertIn("set debug=%s" % _GRUB_DEBUG_SPEC, dump)
-            self.assertIn("serial --unit=0", dump)
+            self.assertIn(
+                f"set debug={_GRUB_DEBUG_SPEC}\n"
+                "serial\n",
+                dump,
+            )
             self.assertIn("terminal_output gfxterm serial", dump)
 
     def test_without_grub_debug_file_stderr_grub_cfg_skips_serial_and_set_debug(self):

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
-from ..__main__ import main
+from ..__main__ import _GRUB_DEBUG_FILE, _GRUB_DEBUG_SPEC, main
 
 
 @contextmanager
@@ -98,6 +98,18 @@ class CliTest(unittest.TestCase):
                 False,
             ),
             ("without --plain-rescue-image", ["--verbose"], " boot/grub/grub.cfg=", True),
+            (
+                "with --save-grub-debug",
+                ["--verbose", "--save-grub-debug"],
+                "file:",
+                True,
+            ),
+            (
+                "without --save-grub-debug qemu file backend",
+                ["--verbose"],
+                "file:",
+                False,
+            ),
         ]
     )
     def test_argument_effect__stdout(self, _label, extra_argv, needle, needed_expected):
@@ -138,6 +150,58 @@ class CliTest(unittest.TestCase):
 
             assertion = self.assertIn if needed_expected else self.assertNotIn
             assertion(needle, stderr.getvalue())
+
+    def test_save_grub_debug_stderr_grub_cfg_has_debug_spec_and_serial(self):
+        with TemporaryDirectory() as tempdir:
+            argv = [None, "--qemu", "true", "--debug", "--save-grub-debug", tempdir]
+            with (
+                patch("sys.stdout", StringIO()),
+                patch("sys.stderr", StringIO()) as stderr,
+                fake_grub2_mkrescue(),
+            ):
+                main(argv)
+            dump = stderr.getvalue()
+            self.assertIn("set debug=%s" % _GRUB_DEBUG_SPEC, dump)
+            self.assertIn("serial --unit=0", dump)
+
+    def test_without_save_grub_debug_stderr_grub_cfg_skips_serial_and_set_debug(self):
+        with TemporaryDirectory() as tempdir:
+            argv = [None, "--qemu", "true", "--debug", tempdir]
+            with (
+                patch("sys.stdout", StringIO()),
+                patch("sys.stderr", StringIO()) as stderr,
+                fake_grub2_mkrescue(),
+            ):
+                main(argv)
+            dump = stderr.getvalue()
+            self.assertNotIn("set debug=", dump)
+            self.assertNotIn("serial --unit=0", dump)
+
+    def test_save_grub_debug_truncates_existing_grub_debug_txt(self):
+        with TemporaryDirectory() as tempcwd:
+            with TemporaryDirectory() as theme_dir:
+                with open(os.path.join(theme_dir, "theme.txt"), "w") as tf:
+                    tf.write("# minimal theme\n")
+                capture = os.path.join(tempcwd, _GRUB_DEBUG_FILE)
+                with open(capture, "w") as xf:
+                    xf.write("discard-me")
+
+                cwd_before = os.getcwd()
+                os.chdir(tempcwd)
+                try:
+                    argv = [None, "--qemu", "true", "--save-grub-debug", theme_dir]
+                    with (
+                        patch("sys.stdout", StringIO()),
+                        patch("sys.stderr", StringIO()),
+                        fake_grub2_mkrescue(),
+                    ):
+                        main(argv)
+                finally:
+                    os.chdir(cwd_before)
+
+            self.assertTrue(os.path.isfile(capture))
+            with open(capture, "rb") as f:
+                self.assertEqual(f.read(), b"")
 
     @parameterized.expand(
         [

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -187,8 +187,7 @@ class CliTest(unittest.TestCase):
                 main(argv)
             dump = stderr.getvalue()
             self.assertIn(
-                f"set debug={_GRUB_DEBUG_SPEC}\n"
-                "serial\n",
+                f"set debug={_GRUB_DEBUG_SPEC}\nserial\n",
                 dump,
             )
             self.assertIn("terminal_output gfxterm serial", dump)

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -187,7 +187,8 @@ class CliTest(unittest.TestCase):
                 main(argv)
             dump = stderr.getvalue()
             self.assertIn("set debug=%s" % _GRUB_DEBUG_SPEC, dump)
-            self.assertIn("serial", dump)
+            self.assertIn("serial --unit=0", dump)
+            self.assertIn("terminal_output gfxterm serial", dump)
 
     def test_without_grub_debug_file_stderr_grub_cfg_skips_serial_and_set_debug(self):
         with TemporaryDirectory() as tempdir:
@@ -200,7 +201,7 @@ class CliTest(unittest.TestCase):
                 main(argv)
             dump = stderr.getvalue()
             self.assertNotIn("set debug=", dump)
-            self.assertNotIn("serial", dump)
+            self.assertNotIn("terminal_output gfxterm serial", dump)
 
     def test_grub_debug_file_truncates_existing_capture_file(self):
         with TemporaryDirectory() as tempcwd:

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
-from ..__main__ import _GRUB_DEBUG_FILE, _GRUB_DEBUG_SPEC, main
+from ..__main__ import _GRUB_DEBUG_SPEC, main
 
 
 @contextmanager
@@ -99,13 +99,7 @@ class CliTest(unittest.TestCase):
             ),
             ("without --plain-rescue-image", ["--verbose"], " boot/grub/grub.cfg=", True),
             (
-                "with --save-grub-debug",
-                ["--verbose", "--save-grub-debug"],
-                "file:",
-                True,
-            ),
-            (
-                "without --save-grub-debug qemu file backend",
+                "without --grub-debug-file qemu serial backend",
                 ["--verbose"],
                 "file:",
                 False,
@@ -124,6 +118,28 @@ class CliTest(unittest.TestCase):
 
             assertion = self.assertIn if needed_expected else self.assertNotIn
             assertion(needle, stdout.getvalue())
+
+    def test_grub_debug_file_adds_qemu_serial_backend(self):
+        with TemporaryDirectory() as tempdir:
+            capture_abs = os.path.join(tempdir, "grub-debug.txt")
+            argv = [
+                None,
+                "--qemu",
+                "true",
+                "--verbose",
+                "--grub-debug-file",
+                capture_abs,
+                tempdir,
+            ]
+            with (
+                patch("sys.stdout", StringIO()) as stdout,
+                patch("sys.stderr", StringIO()),
+                fake_grub2_mkrescue(),
+            ):
+                main(argv)
+            stdout_text = stdout.getvalue()
+            self.assertIn("file:", stdout_text)
+            self.assertIn(capture_abs, stdout_text)
 
     @parameterized.expand(
         [
@@ -151,9 +167,18 @@ class CliTest(unittest.TestCase):
             assertion = self.assertIn if needed_expected else self.assertNotIn
             assertion(needle, stderr.getvalue())
 
-    def test_save_grub_debug_stderr_grub_cfg_has_debug_spec_and_serial(self):
+    def test_grub_debug_file_stderr_grub_cfg_has_debug_spec_and_serial(self):
         with TemporaryDirectory() as tempdir:
-            argv = [None, "--qemu", "true", "--debug", "--save-grub-debug", tempdir]
+            capture_abs = os.path.join(tempdir, "grub-debug.txt")
+            argv = [
+                None,
+                "--qemu",
+                "true",
+                "--debug",
+                "--grub-debug-file",
+                capture_abs,
+                tempdir,
+            ]
             with (
                 patch("sys.stdout", StringIO()),
                 patch("sys.stderr", StringIO()) as stderr,
@@ -164,7 +189,7 @@ class CliTest(unittest.TestCase):
             self.assertIn("set debug=%s" % _GRUB_DEBUG_SPEC, dump)
             self.assertIn("serial --unit=0", dump)
 
-    def test_without_save_grub_debug_stderr_grub_cfg_skips_serial_and_set_debug(self):
+    def test_without_grub_debug_file_stderr_grub_cfg_skips_serial_and_set_debug(self):
         with TemporaryDirectory() as tempdir:
             argv = [None, "--qemu", "true", "--debug", tempdir]
             with (
@@ -177,19 +202,27 @@ class CliTest(unittest.TestCase):
             self.assertNotIn("set debug=", dump)
             self.assertNotIn("serial --unit=0", dump)
 
-    def test_save_grub_debug_truncates_existing_grub_debug_txt(self):
+    def test_grub_debug_file_truncates_existing_capture_file(self):
         with TemporaryDirectory() as tempcwd:
             with TemporaryDirectory() as theme_dir:
                 with open(os.path.join(theme_dir, "theme.txt"), "w") as tf:
                     tf.write("# minimal theme\n")
-                capture = os.path.join(tempcwd, _GRUB_DEBUG_FILE)
+                capture_relative = "grub-debug.txt"
+                capture = os.path.join(tempcwd, capture_relative)
                 with open(capture, "w") as xf:
                     xf.write("discard-me")
 
                 cwd_before = os.getcwd()
                 os.chdir(tempcwd)
                 try:
-                    argv = [None, "--qemu", "true", "--save-grub-debug", theme_dir]
+                    argv = [
+                        None,
+                        "--qemu",
+                        "true",
+                        "--grub-debug-file",
+                        capture_relative,
+                        theme_dir,
+                    ]
                     with (
                         patch("sys.stdout", StringIO()),
                         patch("sys.stderr", StringIO()),

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -101,7 +101,7 @@ class CliTest(unittest.TestCase):
             (
                 "without --grub-debug-file qemu serial backend",
                 ["--verbose"],
-                "file:",
+                "-serial",
                 False,
             ),
         ]

--- a/grub2_theme_preview/tests/test_main.py
+++ b/grub2_theme_preview/tests/test_main.py
@@ -187,7 +187,7 @@ class CliTest(unittest.TestCase):
                 main(argv)
             dump = stderr.getvalue()
             self.assertIn("set debug=%s" % _GRUB_DEBUG_SPEC, dump)
-            self.assertIn("serial --unit=0", dump)
+            self.assertIn("serial", dump)
 
     def test_without_grub_debug_file_stderr_grub_cfg_skips_serial_and_set_debug(self):
         with TemporaryDirectory() as tempdir:
@@ -200,7 +200,7 @@ class CliTest(unittest.TestCase):
                 main(argv)
             dump = stderr.getvalue()
             self.assertNotIn("set debug=", dump)
-            self.assertNotIn("serial --unit=0", dump)
+            self.assertNotIn("serial", dump)
 
     def test_grub_debug_file_truncates_existing_capture_file(self):
         with TemporaryDirectory() as tempcwd:


### PR DESCRIPTION
So for my specific problem at #519, I had to go deep into debugging and ended up making this feature, which is optional and does not interfere in current functionality.

The generated file removes parts of the logs that tend to not help, but you can always tweak to add or exclude more debug at `_GRUB_DEBUG_SPEC`. Right now it's at a sweet spot in my opinion, and does not produce any personal information.

This can help anyone to debug themes even further in the future.

